### PR TITLE
test/run.vim wrongly passes all tests

### DIFF
--- a/test/run.vim
+++ b/test/run.vim
@@ -18,7 +18,7 @@ function! s:run()
     catch
       call writefile([v:exception], outfile)
     endtry
-    if system(printf('diff %s %s', shellescape(okfile), shellescape(outfile))) == 0
+    if system(printf('diff %s %s', shellescape(okfile), shellescape(outfile))) == ""
       echo printf('%s => ok', fnamemodify(vimfile, ':t'))
     else
       echoerr printf('%s => ng', fnamemodify(vimfile, ':t'))


### PR DESCRIPTION
diffコマンドをsystem()で実行した後、system()の返り値が0であればテストを成功とみなしていますが、system()の返り値は文字列なので、全てのテストが間違って成功しちゃってます。

P.S.
ちなみに`vimlparser#test()`という関数もあるようですが、どちらを使ってテストするのが正しいんでしょうか？
またどのようにテストすればいいですか？
今回は`vim -S test/run.vim -c quit`のようにしてテストを実行させました。
