### PR TITLE
add test/run.bat, test/run.sh

### DIFF
--- a/test/run.bat
+++ b/test/run.bat
@@ -1,0 +1,2 @@
+@echo off
+vim -u NONE -N --cmd "let &rtp .= ',' . getcwd()" -S test/run.vim

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+vim -u NONE -N --cmd "let &rtp .= ',' . getcwd()" -S test/run.vim

--- a/test/run.vim
+++ b/test/run.vim
@@ -19,11 +19,14 @@ function! s:run()
       call writefile([v:exception], outfile)
     endtry
     if system(printf('diff %s %s', shellescape(okfile), shellescape(outfile))) == ""
-      echo printf('%s => ok', fnamemodify(vimfile, ':t'))
+      let line = printf('%s => ok', fnamemodify(vimfile, ':t'))
     else
-      echoerr printf('%s => ng', fnamemodify(vimfile, ':t'))
+      let line = printf('%s => ng', fnamemodify(vimfile, ':t'))
     endif
+    call append(line('$'), line)
   endfor
+  syntax enable
+  match Error /^.* => ng$/
 endfunction
 
 call s:run()


### PR DESCRIPTION
#7 で言ってた件です。

> 後で上記手順を実行するバッチファイルとシェルスクリプト送るかもです。
### 変更点
1. test/run.bat と test/run.sh を追加しました。
2. `:echo`してた結果はVimのバッファに出力するようにしました。
3. NGの行はErrorグループでハイライトするようにしました。
### 提案
1. テストスクリプトは test.bat と test.sh のが短いのでそっちのが良いでしょうか？
2. 出力結果を`gf`や`<C-w>f`で開けるようなパスを出力するといいかもしれません。

> test_xxx_colonsharp.vim => ng

を

> test/test_xxx_colonsharp.vim => ng

にするか、`'path'`オプションをいじって`test/`以下も開けるようにするといいかもしれません。
1. `:set buftype=nofile` すべき？
