### PR TITLE
Make pprint friendly

### DIFF
--- a/py/vimlfunc.py
+++ b/py/vimlfunc.py
@@ -13,7 +13,7 @@ def main():
         print(line)
 
 class AttributeDict(dict):
-    __getattribute__ = dict.__getitem__
+    __getattr__ = dict.__getitem__
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
 

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -13,7 +13,7 @@ def main():
         print(line)
 
 class AttributeDict(dict):
-    __getattribute__ = dict.__getitem__
+    __getattr__ = dict.__getitem__
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
 


### PR DESCRIPTION
pprint can not work when `__getattribute__` is override.
Because overriding `__getattribute__` hide some `dict`'s methods.

Instead, use `__getattr__`.

See [特殊メソッド名](http://diveintopython3-ja.rdy.jp/special-method-names.html#computed-attributes) (Japanese reference)
