### PR TITLE
fix error for `let a.b.=1`

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -3442,6 +3442,7 @@ function! s:LvalueParser.parse_lv8()
         endif
       endif
       let left = node
+      unlet node
     elseif !s:iswhite(c) && token.type == s:TOKEN_DOT
       let node = self.parse_dot(token, left)
       if node is s:NIL
@@ -3449,6 +3450,7 @@ function! s:LvalueParser.parse_lv8()
         break
       endif
       let left = node
+      unlet node
     else
       call self.reader.seek_set(pos)
       break


### PR DESCRIPTION
`s:NIL` が返ってくる場合に `E706` になっていたので修正しました。
