### PR TITLE
Fix typo

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -1585,7 +1585,7 @@ endfunction
 
 function! s:VimLParser.parse_cmd_finally()
   if self.context[0].type != s:NODE_TRY && self.context[0].type != s:NODE_CATCH
-    throw s:Err('E606: :finally without :try', self.ea.cmdos)
+    throw s:Err('E606: :finally without :try', self.ea.cmdpos)
   endif
   if self.context[0].type != s:NODE_TRY
     call self.pop_context()


### PR DESCRIPTION
s/cmdos/cmdpos/

`cmdos` field doens't exists
