### PR TITLE
update builtin_commands

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -2352,6 +2352,23 @@ let s:VimLParser.builtin_commands = [
       \ {'name': 'Print', 'minlen': 1, 'flags': 'RANGE|WHOLEFOLD|COUNT|EXFLAGS|TRLBAR|CMDWIN', 'parser': 'parse_cmd_common'},
       \ {'name': 'X', 'minlen': 1, 'flags': 'TRLBAR', 'parser': 'parse_cmd_common'},
       \ {'name': '~', 'minlen': 1, 'flags': 'RANGE|WHOLEFOLD|EXTRA|CMDWIN|MODIFY', 'parser': 'parse_cmd_common'},
+      \
+      \ {'flags': 'TRLBAR', 'minlen': 3, 'name': 'cbottom', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'BANG|NEEDARG|EXTRA|NOTRLCOM|RANGE|NOTADR|DFLALL', 'minlen': 3, 'name': 'cdo', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'BANG|NEEDARG|EXTRA|NOTRLCOM|RANGE|NOTADR|DFLALL', 'minlen': 3, 'name': 'cfdo', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'TRLBAR', 'minlen': 3, 'name': 'chistory', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'TRLBAR|CMDWIN', 'minlen': 3, 'name': 'clearjumps', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'BANG|NEEDARG|EXTRA|NOTRLCOM', 'minlen': 4, 'name': 'filter', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'RANGE|NOTADR|COUNT|TRLBAR', 'minlen': 5, 'name': 'helpclose', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'TRLBAR', 'minlen': 3, 'name': 'lbottom', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'BANG|NEEDARG|EXTRA|NOTRLCOM|RANGE|NOTADR|DFLALL', 'minlen': 2, 'name': 'ldo', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'BANG|NEEDARG|EXTRA|NOTRLCOM|RANGE|NOTADR|DFLALL', 'minlen': 3, 'name': 'lfdo', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'TRLBAR', 'minlen': 3, 'name': 'lhistory', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'BANG|EXTRA|TRLBAR|CMDWIN', 'minlen': 3, 'name': 'llist', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'NEEDARG|EXTRA|NOTRLCOM', 'minlen': 3, 'name': 'noswapfile', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'BANG|FILE1|NEEDARG|TRLBAR|SBOXOK|CMDWIN', 'minlen': 2, 'name': 'packadd', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'BANG|TRLBAR|SBOXOK|CMDWIN', 'minlen': 5, 'name': 'packloadall', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'TRLBAR|CMDWIN|SBOXOK', 'minlen': 3, 'name': 'smile', 'parser': 'parse_cmd_common'},
       \]
 
 let s:ExprTokenizer = {}

--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -2369,6 +2369,10 @@ let s:VimLParser.builtin_commands = [
       \ {'flags': 'BANG|FILE1|NEEDARG|TRLBAR|SBOXOK|CMDWIN', 'minlen': 2, 'name': 'packadd', 'parser': 'parse_cmd_common'},
       \ {'flags': 'BANG|TRLBAR|SBOXOK|CMDWIN', 'minlen': 5, 'name': 'packloadall', 'parser': 'parse_cmd_common'},
       \ {'flags': 'TRLBAR|CMDWIN|SBOXOK', 'minlen': 3, 'name': 'smile', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'RANGE|EXTRA|NEEDARG|CMDWIN', 'minlen': 3, 'name': 'pyx', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'RANGE|DFLALL|EXTRA|NEEDARG|CMDWIN', 'minlen': 4, 'name': 'pyxdo', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'RANGE|EXTRA|NEEDARG|CMDWIN', 'minlen': 7, 'name': 'pythonx', 'parser': 'parse_cmd_common'},
+      \ {'flags': 'RANGE|FILE1|NEEDARG|CMDWIN', 'minlen': 4, 'name': 'pyxfile', 'parser': 'parse_cmd_common'},
       \]
 
 let s:ExprTokenizer = {}


### PR DESCRIPTION
Hi! I updated builtin commands.
Commands are listed by below script.
`minlen` is calculated automatically by this script.
It assumes `parser` is `parse_cmd_common`

<details>

``` vim
" create builtin command table
let s:ex_cmds_h = '/home/haya14busa/src/github.com/vim/vim/src/ex_cmds.h'

let s:Trie = {
\   'data': {},
\ }

function! s:Trie.new() abort
  return deepcopy(self)
endfunction

function! s:Trie.add(s) abort
  let d = self.data
  for c in split(a:s, '\zs')
    if !has_key(d, c)
      let d[c] = {}
    endif
    let d = d[c]
  endfor
endfunction

function! s:Trie.in(s) abort
  let d = self.data
  for c in split(a:s, '\zs')
    if has_key(d, c)
      let d = d[c]
    else
      return v:false
    endif
  endfor
  return v:true
endfunction

function! s:Trie.common(s) abort
  let d = self.data
  let common = []
  for c in split(a:s, '\zs')
    if has_key(d, c)
      let common = add(common, c)
      let d = d[c]
    else
      break
    endif
  endfor
  return join(common, '')
endfunction

function! s:Trie.remove(s) abort
  let d = self.data
  let kss = [[]]
  for c in split(a:s, '\zs')
    if has_key(d, c)
      let kss = add(kss, copy(kss[-1]) + [c])
      let d = d[c]
    else
      return v:false
    endif
  endfor
  let kss = kss[1:]
  let kss = reverse(kss)
  for ks in kss
    let d = self.data
    for [i, k] in map(copy(ks[:-2]), {i, k->[i,k]})
      let pd = d
      let nk = ks[i+1]
      let d = d[k]
    endfor
    if empty(pd[k][nk])
      unlet pd[k][nk]
    else
      return v:true
    endif
  endfor
  return v:true
endfunction

function! s:gen(ex_cmds_h) abort
  let lines = readfile(a:ex_cmds_h)

  " { 'name': string, 'flags': string, 'minlen': int, 'parser': string}
  let cmds = []

  let trie = s:Trie.new()

  let cumname = ''
  for [i, line] in map(copy(lines), {i, l -> [i, l]})
    if line =~# '^EX('
      let name = matchstr(line, '"\zs.*\ze",')
      let flags = matchstr(lines[i+1], '\t\+\zs.*\ze,$')

      let minlen = len(trie.common(name)) + 1
      call trie.add(name)

      let cmd = {
      \   'name': name,
      \   'flags': flags,
      \   'minlen': minlen,
      \ }
      let cmds = add(cmds, cmd)
    endif
  endfor
  return cmds
endfunction

function! s:gen_new_builtin(existing, latest) abort
  let existing_names = {}
  for cmd in a:existing
    let existing_names[cmd.name] = v:true
  endfor
  let newcmds = []
  for cmd in filter(copy(a:latest), {_, c -> !has_key(existing_names, c.name)})
    let newcmds = add(newcmds, extend(cmd, {'parser': 'parse_cmd_common'}))
  endfor
  return newcmds
endfunction

function! s:gen_viml(newcmds) abort
  let lines = []
  for c in a:newcmds
    let lines = add(lines, '      \ ' . string(c) . ',')
  endfor
  return join(lines, "\n")
endfunction

" -- main

function! s:vimlparser_new_cmds() abort
  let vimlparser = vimlparser#import()
  let latest = s:gen(s:ex_cmds_h)
  let new_cmds = s:gen_new_builtin(vimlparser#import().VimLParser.builtin_commands, latest)
  echo s:gen_viml(new_cmds)
endfunction
call s:vimlparser_new_cmds()
```

</details>
