### PR TITLE
fix parse :syntax with <bar>

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -1818,6 +1818,16 @@ function! s:VimLParser.parse_wincmd()
   call self.add_node(node)
 endfunction
 
+" FIXME: validate argument
+function! s:VimLParser.parse_cmd_syntax()
+  let end = self.separate_nextcmd()
+  let node = s:Node(s:NODE_EXCMD)
+  let node.pos = self.ea.cmdpos
+  let node.ea = self.ea
+  let node.str = self.reader.getstr(self.ea.linepos, end)
+  call self.add_node(node)
+endfunction
+
 let s:VimLParser.neovim_additional_commands = [
       \ {'name': 'tnoremap', 'minlen': 8, 'flags': 'EXTRA|TRLBAR|NOTRLCOM|USECTRLV|CMDWIN', 'parser': 'parse_cmd_common'}]
 
@@ -2247,7 +2257,7 @@ let s:VimLParser.builtin_commands = [
       \ {'name': 'suspend', 'minlen': 3, 'flags': 'TRLBAR|BANG|CMDWIN', 'parser': 'parse_cmd_common'},
       \ {'name': 'sview', 'minlen': 2, 'flags': 'BANG|FILE1|RANGE|NOTADR|EDITCMD|ARGOPT|TRLBAR', 'parser': 'parse_cmd_common'},
       \ {'name': 'swapname', 'minlen': 2, 'flags': 'TRLBAR|CMDWIN', 'parser': 'parse_cmd_common'},
-      \ {'name': 'syntax', 'minlen': 2, 'flags': 'EXTRA|NOTRLCOM|CMDWIN', 'parser': 'parse_cmd_common'},
+      \ {'name': 'syntax', 'minlen': 2, 'flags': 'EXTRA|NOTRLCOM|CMDWIN', 'parser': 'parse_cmd_syntax'},
       \ {'name': 'syntime', 'minlen': 5, 'flags': 'NEEDARG|WORD1|TRLBAR|CMDWIN', 'parser': 'parse_cmd_common'},
       \ {'name': 'syncbind', 'minlen': 4, 'flags': 'TRLBAR', 'parser': 'parse_cmd_common'},
       \ {'name': 't', 'minlen': 1, 'flags': 'RANGE|WHOLEFOLD|EXTRA|TRLBAR|CMDWIN|MODIFY', 'parser': 'parse_cmd_common'},

--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -1820,7 +1820,21 @@ endfunction
 
 " FIXME: validate argument
 function! s:VimLParser.parse_cmd_syntax()
-  let end = self.separate_nextcmd()
+  let end = self.reader.getpos()
+  while 1
+    let end = self.reader.getpos()
+    let c = self.reader.peek()
+    if c == "/" || c == "'" || c == "\""
+      call self.reader.getn(1)
+      call self.parse_pattern(c)
+    elseif c == "="
+      call self.reader.getn(1)
+      call self.parse_pattern(" ")
+    elseif self.ends_excmds(c)
+      break
+    endif
+    call self.reader.getn(1)
+  endwhile
   let node = s:Node(s:NODE_EXCMD)
   let node.pos = self.ea.cmdpos
   let node.ea = self.ea

--- a/test/test_syncmd.ok
+++ b/test/test_syncmd.ok
@@ -3,3 +3,6 @@
 (excmd "syntax")
 (excmd "syntax enable")
 (excmd "syntax list GroupName")
+(excmd "syn match pythonError \"[&|]\\{2,}\" display")
+(excmd "syntax match qfFileName /^\\zs\\S[^|]\\+\\/\\ze[^|\\/]\\+\\/[^|\\/]\\+|/ conceal cchar=+")
+(excmd "syntax region jsString start=+\"+ skip=+\\\\\\(\"\\|$\\)+ end=+\"\\|$+ contains=jsSpecial,@Spell extend")

--- a/test/test_syncmd.ok
+++ b/test/test_syncmd.ok
@@ -1,0 +1,5 @@
+(if 1
+  (excmd "syntax on "))
+(excmd "syntax")
+(excmd "syntax enable")
+(excmd "syntax list GroupName")

--- a/test/test_syncmd.vim
+++ b/test/test_syncmd.vim
@@ -1,0 +1,4 @@
+if 1 | syntax on | endif
+syntax
+syntax enable
+syntax list GroupName

--- a/test/test_syncmd.vim
+++ b/test/test_syncmd.vim
@@ -2,3 +2,6 @@ if 1 | syntax on | endif
 syntax
 syntax enable
 syntax list GroupName
+syn match pythonError "[&|]\{2,}" display
+syntax match qfFileName /^\zs\S[^|]\+\/\ze[^|\/]\+\/[^|\/]\+|/ conceal cchar=+
+syntax region jsString start=+"+ skip=+\\\("\|$\)+ end=+"\|$+ contains=jsSpecial,@Spell extend


### PR DESCRIPTION
vimlparser fails to parse `if 1 | syntax on | endif` and I fixed it.

it's somewhat workaround fix though...
