### PR TITLE
Fix cmdpos typo for .js/.py

### DIFF
--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -1860,7 +1860,7 @@ VimLParser.prototype.parse_cmd_catch = function() {
 
 VimLParser.prototype.parse_cmd_finally = function() {
     if (this.context[0].type != NODE_TRY && this.context[0].type != NODE_CATCH) {
-        throw Err("E606: :finally without :try", this.ea.cmdos);
+        throw Err("E606: :finally without :try", this.ea.cmdpos);
     }
     if (this.context[0].type != NODE_TRY) {
         this.pop_context();

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -1499,7 +1499,7 @@ class VimLParser:
 
     def parse_cmd_finally(self):
         if self.context[0].type != NODE_TRY and self.context[0].type != NODE_CATCH:
-            raise VimLParserException(Err("E606: :finally without :try", self.ea.cmdos))
+            raise VimLParserException(Err("E606: :finally without :try", self.ea.cmdpos))
         if self.context[0].type != NODE_TRY:
             self.pop_context()
         node = Node(NODE_FINALLY)


### PR DESCRIPTION
Follow-up to 562743d / https://github.com/vim-jp/vim-vimlparser/pull/34.