### PR TITLE
Add :nos[wapfile] as modifier

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -568,6 +568,8 @@ function! s:VimLParser.parse_command_modifiers()
       call add(modifiers, {'name': 'leftabove'})
     elseif stridx('noautocmd', k) == 0 && len(k) >= 3 " noa\%[utocmd]
       call add(modifiers, {'name': 'noautocmd'})
+    elseif stridx('noswapfile', k) == 0 && len(k) >= 3 " :nos\%[wapfile]
+      call add(modifiers, {'name': 'noswapfile'})
     elseif stridx('rightbelow', k) == 0 && len(k) >= 6 "rightb\%[elow]
       call add(modifiers, {'name': 'rightbelow'})
     elseif stridx('sandbox', k) == 0 && len(k) >= 3 " san\%[dbox]

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -769,6 +769,10 @@ VimLParser.prototype.parse_command_modifiers = function() {
             // noa\%[utocmd]
             viml_add(modifiers, {"name":"noautocmd"});
         }
+        else if (viml_stridx("noswapfile", k) == 0 && viml_len(k) >= 3) {
+            // :nos\%[wapfile]
+            viml_add(modifiers, {"name":"noswapfile"});
+        }
         else if (viml_stridx("rightbelow", k) == 0 && viml_len(k) >= 6) {
             //rightb\%[elow]
             viml_add(modifiers, {"name":"rightbelow"});

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -662,6 +662,9 @@ class VimLParser:
             elif viml_stridx("noautocmd", k) == 0 and viml_len(k) >= 3:
                 # noa\%[utocmd]
                 viml_add(modifiers, AttributeDict({"name":"noautocmd"}))
+            elif viml_stridx("noswapfile", k) == 0 and viml_len(k) >= 3:
+                # :nos\%[wapfile]
+                viml_add(modifiers, AttributeDict({"name":"noswapfile"}))
             elif viml_stridx("rightbelow", k) == 0 and viml_len(k) >= 6:
                 #rightb\%[elow]
                 viml_add(modifiers, AttributeDict({"name":"rightbelow"}))

--- a/test/test_modifier_commands.ok
+++ b/test/test_modifier_commands.ok
@@ -1,0 +1,1 @@
+(call (Func))

--- a/test/test_modifier_commands.ok
+++ b/test/test_modifier_commands.ok
@@ -1,1 +1,2 @@
 (call (Func))
+(call (Func))

--- a/test/test_modifier_commands.vim
+++ b/test/test_modifier_commands.vim
@@ -1,3 +1,6 @@
 aboveleft belowright botright browse confirm hide keepalt keepjumps
 	      \ keepmarks keeppatterns lockmarks noswapfile silent tab
 	      \ topleft verbose vertical call Func()
+abo bel bo bro conf hid keepalt keepj
+	      \ kee keepp loc nos sil tab
+	      \ to verb vert call Func()

--- a/test/test_modifier_commands.vim
+++ b/test/test_modifier_commands.vim
@@ -1,0 +1,3 @@
+aboveleft belowright botright browse confirm hide keepalt keepjumps
+	      \ keepmarks keeppatterns lockmarks noswapfile silent tab
+	      \ topleft verbose vertical call Func()


### PR DESCRIPTION
[Vim 7.4.213](https://github.com/vim/vim/commit/5803ae6c076b1d61381afe27fcdedac61dd2cda9) で追加された `:nos[wapfile]` コマンドを modifier として追加しました。
7.4.213 時点では省略形は `noswap[file]` ですが [7.4.2127](https://github.com/vim/vim/commit/3bcfca3ab4db415d0e750e00204dd25a91fcee77) で `:nos[wapfile]` に変更されています（doc は https://github.com/vim/vim/commit/7e38ea2fb6a781213c85824dcf9ccb582fbc5c43 で修正）。
また、全ての modifier commands は（テストスクリプトに漏れがなければ） [src/testdir/test_usercommands.vim](https://github.com/vim/vim/blob/c3c766ea8c35f5b2bd45fb3d74d0ae46b2d8c24f/src/testdir/test_usercommands.vim#L52-L54) で確認できます。