### PR TITLE
Use underscore for unused var

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -634,11 +634,11 @@ function! s:VimLParser.parse_range()
         call add(tokens, "'" . m)
       elseif c ==# '/'
         call self.reader.getn(1)
-        let [pattern, endc] = self.parse_pattern(c)
+        let [pattern, _] = self.parse_pattern(c)
         call add(tokens, pattern)
       elseif c ==# '?'
         call self.reader.getn(1)
-        let [pattern, endc] = self.parse_pattern(c)
+        let [pattern, _] = self.parse_pattern(c)
         call add(tokens, pattern)
       elseif c ==# '\'
         let m = self.reader.p(1)
@@ -1078,7 +1078,7 @@ function! s:VimLParser.skip_vimgrep_pat()
   else
     " :vimgrep /pattern/[g][j] fname
     let c = self.reader.getn(1)
-    let [pattern, endc] = self.parse_pattern(c)
+    let [_, endc] = self.parse_pattern(c)
     if c !=# endc
       return
     endif
@@ -1615,7 +1615,7 @@ function! s:VimLParser.parse_cmd_catch()
   let node.pattern = s:NIL
   call self.reader.skip_white()
   if !self.ends_excmds(self.reader.peek())
-    let [node.pattern, endc] = self.parse_pattern(self.reader.get())
+    let [node.pattern, _] = self.parse_pattern(self.reader.get())
   endif
   call add(self.context[0].catch, node)
   call self.push_context(node)

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -857,14 +857,14 @@ VimLParser.prototype.parse_range = function() {
                 this.reader.getn(1);
                 var __tmp = this.parse_pattern(c);
                 var pattern = __tmp[0];
-                var endc = __tmp[1];
+                var _ = __tmp[1];
                 viml_add(tokens, pattern);
             }
             else if (c == "?") {
                 this.reader.getn(1);
                 var __tmp = this.parse_pattern(c);
                 var pattern = __tmp[0];
-                var endc = __tmp[1];
+                var _ = __tmp[1];
                 viml_add(tokens, pattern);
             }
             else if (c == "\\") {
@@ -1318,7 +1318,7 @@ VimLParser.prototype.skip_vimgrep_pat = function() {
         // :vimgrep /pattern/[g][j] fname
         var c = this.reader.getn(1);
         var __tmp = this.parse_pattern(c);
-        var pattern = __tmp[0];
+        var _ = __tmp[0];
         var endc = __tmp[1];
         if (c != endc) {
             return;
@@ -1864,7 +1864,7 @@ VimLParser.prototype.parse_cmd_catch = function() {
     if (!this.ends_excmds(this.reader.peek())) {
         var __tmp = this.parse_pattern(this.reader.get());
         node.pattern = __tmp[0];
-        var endc = __tmp[1];
+        var _ = __tmp[1];
     }
     viml_add(this.context[0].catch, node);
     this.push_context(node);

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -725,11 +725,11 @@ class VimLParser:
                     viml_add(tokens, "'" + m)
                 elif c == "/":
                     self.reader.getn(1)
-                    pattern, endc = self.parse_pattern(c)
+                    pattern, _ = self.parse_pattern(c)
                     viml_add(tokens, pattern)
                 elif c == "?":
                     self.reader.getn(1)
-                    pattern, endc = self.parse_pattern(c)
+                    pattern, _ = self.parse_pattern(c)
                     viml_add(tokens, pattern)
                 elif c == "\\":
                     m = self.reader.p(1)
@@ -1061,7 +1061,7 @@ class VimLParser:
         else:
             # :vimgrep /pattern/[g][j] fname
             c = self.reader.getn(1)
-            pattern, endc = self.parse_pattern(c)
+            _, endc = self.parse_pattern(c)
             if c != endc:
                 return
             while self.reader.p(0) == "g" or self.reader.p(0) == "j":
@@ -1503,7 +1503,7 @@ class VimLParser:
         node.pattern = NIL
         self.reader.skip_white()
         if not self.ends_excmds(self.reader.peek()):
-            node.pattern, endc = self.parse_pattern(self.reader.get())
+            node.pattern, _ = self.parse_pattern(self.reader.get())
         viml_add(self.context[0].catch, node)
         self.push_context(node)
 


### PR DESCRIPTION
Use _ for go-vimlparser (https://github.com/haya14busa/go-vimlparser)
because Go doesn't allow unused variables.

This change is basically just for Go, but I think it's acceptable.