### PR TITLE
Fix return for translation to typed language

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -1112,7 +1112,7 @@ function! s:VimLParser.parse_cmd_append()
 endfunction
 
 function! s:VimLParser.parse_cmd_insert()
-  return self.parse_cmd_append()
+  call self.parse_cmd_append()
 endfunction
 
 function! s:VimLParser.parse_cmd_loadkeymap()
@@ -1170,27 +1170,27 @@ function! s:VimLParser.parse_cmd_lua()
 endfunction
 
 function! s:VimLParser.parse_cmd_mzscheme()
-  return self.parse_cmd_lua()
+  call self.parse_cmd_lua()
 endfunction
 
 function! s:VimLParser.parse_cmd_perl()
-  return self.parse_cmd_lua()
+  call self.parse_cmd_lua()
 endfunction
 
 function! s:VimLParser.parse_cmd_python()
-  return self.parse_cmd_lua()
+  call self.parse_cmd_lua()
 endfunction
 
 function! s:VimLParser.parse_cmd_python3()
-  return self.parse_cmd_lua()
+  call self.parse_cmd_lua()
 endfunction
 
 function! s:VimLParser.parse_cmd_ruby()
-  return self.parse_cmd_lua()
+  call self.parse_cmd_lua()
 endfunction
 
 function! s:VimLParser.parse_cmd_tcl()
-  return self.parse_cmd_lua()
+  call self.parse_cmd_lua()
 endfunction
 
 function! s:VimLParser.parse_cmd_finish()
@@ -1202,7 +1202,7 @@ endfunction
 
 " FIXME
 function! s:VimLParser.parse_cmd_usercmd()
-  return self.parse_cmd_common()
+  call self.parse_cmd_common()
 endfunction
 
 function! s:VimLParser.parse_cmd_function()
@@ -1212,13 +1212,15 @@ function! s:VimLParser.parse_cmd_function()
   " :function
   if self.ends_excmds(self.reader.peek())
     call self.reader.seek_set(pos)
-    return self.parse_cmd_common()
+    call self.parse_cmd_common()
+    return
   endif
 
   " :function /pattern
   if self.reader.peekn(1) ==# '/'
     call self.reader.seek_set(pos)
-    return self.parse_cmd_common()
+    call self.parse_cmd_common()
+    return
   endif
 
   let left = self.parse_lvalue_func()
@@ -1235,7 +1237,8 @@ function! s:VimLParser.parse_cmd_function()
   " :function {name}
   if self.reader.peekn(1) !=# '('
     call self.reader.seek_set(pos)
-    return self.parse_cmd_common()
+    call self.parse_cmd_common()
+    return
   endif
 
   " :function[!] {name}([arguments]) [range] [abort] [dict] [closure]
@@ -1383,7 +1386,8 @@ function! s:VimLParser.parse_cmd_let()
   " :let
   if self.ends_excmds(self.reader.peek())
     call self.reader.seek_set(pos)
-    return self.parse_cmd_common()
+    call self.parse_cmd_common()
+    return
   endif
 
   let lhs = self.parse_letlhs()
@@ -1394,7 +1398,8 @@ function! s:VimLParser.parse_cmd_let()
   " :let {var-name} ..
   if self.ends_excmds(s1) || (s2 !=# '+=' && s2 !=# '-=' && s2 !=# '.=' && s1 !=# '=')
     call self.reader.seek_set(pos)
-    return self.parse_cmd_common()
+    call self.parse_cmd_common()
+    return
   endif
 
   " :let left op right
@@ -3915,51 +3920,51 @@ function! s:Compiler.compile(node)
   if a:node.type == s:NODE_TOPLEVEL
     return self.compile_toplevel(a:node)
   elseif a:node.type == s:NODE_COMMENT
-    return self.compile_comment(a:node)
+    call self.compile_comment(a:node)
   elseif a:node.type == s:NODE_EXCMD
-    return self.compile_excmd(a:node)
+    call self.compile_excmd(a:node)
   elseif a:node.type == s:NODE_FUNCTION
-    return self.compile_function(a:node)
+    call self.compile_function(a:node)
   elseif a:node.type == s:NODE_DELFUNCTION
-    return self.compile_delfunction(a:node)
+    call self.compile_delfunction(a:node)
   elseif a:node.type == s:NODE_RETURN
-    return self.compile_return(a:node)
+    call self.compile_return(a:node)
   elseif a:node.type == s:NODE_EXCALL
-    return self.compile_excall(a:node)
+    call self.compile_excall(a:node)
   elseif a:node.type == s:NODE_LET
-    return self.compile_let(a:node)
+    call self.compile_let(a:node)
   elseif a:node.type == s:NODE_UNLET
-    return self.compile_unlet(a:node)
+    call self.compile_unlet(a:node)
   elseif a:node.type == s:NODE_LOCKVAR
-    return self.compile_lockvar(a:node)
+    call self.compile_lockvar(a:node)
   elseif a:node.type == s:NODE_UNLOCKVAR
-    return self.compile_unlockvar(a:node)
+    call self.compile_unlockvar(a:node)
   elseif a:node.type == s:NODE_IF
-    return self.compile_if(a:node)
+    call self.compile_if(a:node)
   elseif a:node.type == s:NODE_WHILE
-    return self.compile_while(a:node)
+    call self.compile_while(a:node)
   elseif a:node.type == s:NODE_FOR
-    return self.compile_for(a:node)
+    call self.compile_for(a:node)
   elseif a:node.type == s:NODE_CONTINUE
-    return self.compile_continue(a:node)
+    call self.compile_continue(a:node)
   elseif a:node.type == s:NODE_BREAK
-    return self.compile_break(a:node)
+    call self.compile_break(a:node)
   elseif a:node.type == s:NODE_TRY
-    return self.compile_try(a:node)
+    call self.compile_try(a:node)
   elseif a:node.type == s:NODE_THROW
-    return self.compile_throw(a:node)
+    call self.compile_throw(a:node)
   elseif a:node.type == s:NODE_ECHO
-    return self.compile_echo(a:node)
+    call self.compile_echo(a:node)
   elseif a:node.type == s:NODE_ECHON
-    return self.compile_echon(a:node)
+    call self.compile_echon(a:node)
   elseif a:node.type == s:NODE_ECHOHL
-    return self.compile_echohl(a:node)
+    call self.compile_echohl(a:node)
   elseif a:node.type == s:NODE_ECHOMSG
-    return self.compile_echomsg(a:node)
+    call self.compile_echomsg(a:node)
   elseif a:node.type == s:NODE_ECHOERR
-    return self.compile_echoerr(a:node)
+    call self.compile_echoerr(a:node)
   elseif a:node.type == s:NODE_EXECUTE
-    return self.compile_execute(a:node)
+    call self.compile_execute(a:node)
   elseif a:node.type == s:NODE_TERNARY
     return self.compile_ternary(a:node)
   elseif a:node.type == s:NODE_OR
@@ -4079,6 +4084,7 @@ function! s:Compiler.compile(node)
   else
     throw printf('Compiler: unknown node: %s', string(a:node))
   endif
+  return s:NIL
 endfunction
 
 function! s:Compiler.compile_body(body)

--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -3921,50 +3921,73 @@ function! s:Compiler.compile(node)
     return self.compile_toplevel(a:node)
   elseif a:node.type == s:NODE_COMMENT
     call self.compile_comment(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_EXCMD
     call self.compile_excmd(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_FUNCTION
     call self.compile_function(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_DELFUNCTION
     call self.compile_delfunction(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_RETURN
     call self.compile_return(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_EXCALL
     call self.compile_excall(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_LET
     call self.compile_let(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_UNLET
     call self.compile_unlet(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_LOCKVAR
     call self.compile_lockvar(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_UNLOCKVAR
     call self.compile_unlockvar(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_IF
     call self.compile_if(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_WHILE
     call self.compile_while(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_FOR
     call self.compile_for(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_CONTINUE
     call self.compile_continue(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_BREAK
     call self.compile_break(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_TRY
     call self.compile_try(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_THROW
     call self.compile_throw(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_ECHO
     call self.compile_echo(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_ECHON
     call self.compile_echon(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_ECHOHL
     call self.compile_echohl(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_ECHOMSG
     call self.compile_echomsg(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_ECHOERR
     call self.compile_echoerr(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_EXECUTE
     call self.compile_execute(a:node)
+    return s:NIL
   elseif a:node.type == s:NODE_TERNARY
     return self.compile_ternary(a:node)
   elseif a:node.type == s:NODE_OR

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -1358,7 +1358,7 @@ VimLParser.prototype.parse_cmd_append = function() {
 }
 
 VimLParser.prototype.parse_cmd_insert = function() {
-    return this.parse_cmd_append();
+    this.parse_cmd_append();
 }
 
 VimLParser.prototype.parse_cmd_loadkeymap = function() {
@@ -1417,27 +1417,27 @@ VimLParser.prototype.parse_cmd_lua = function() {
 }
 
 VimLParser.prototype.parse_cmd_mzscheme = function() {
-    return this.parse_cmd_lua();
+    this.parse_cmd_lua();
 }
 
 VimLParser.prototype.parse_cmd_perl = function() {
-    return this.parse_cmd_lua();
+    this.parse_cmd_lua();
 }
 
 VimLParser.prototype.parse_cmd_python = function() {
-    return this.parse_cmd_lua();
+    this.parse_cmd_lua();
 }
 
 VimLParser.prototype.parse_cmd_python3 = function() {
-    return this.parse_cmd_lua();
+    this.parse_cmd_lua();
 }
 
 VimLParser.prototype.parse_cmd_ruby = function() {
-    return this.parse_cmd_lua();
+    this.parse_cmd_lua();
 }
 
 VimLParser.prototype.parse_cmd_tcl = function() {
-    return this.parse_cmd_lua();
+    this.parse_cmd_lua();
 }
 
 VimLParser.prototype.parse_cmd_finish = function() {
@@ -1449,7 +1449,7 @@ VimLParser.prototype.parse_cmd_finish = function() {
 
 // FIXME
 VimLParser.prototype.parse_cmd_usercmd = function() {
-    return this.parse_cmd_common();
+    this.parse_cmd_common();
 }
 
 VimLParser.prototype.parse_cmd_function = function() {
@@ -1458,12 +1458,14 @@ VimLParser.prototype.parse_cmd_function = function() {
     // :function
     if (this.ends_excmds(this.reader.peek())) {
         this.reader.seek_set(pos);
-        return this.parse_cmd_common();
+        this.parse_cmd_common();
+        return;
     }
     // :function /pattern
     if (this.reader.peekn(1) == "/") {
         this.reader.seek_set(pos);
-        return this.parse_cmd_common();
+        this.parse_cmd_common();
+        return;
     }
     var left = this.parse_lvalue_func();
     this.reader.skip_white();
@@ -1477,7 +1479,8 @@ VimLParser.prototype.parse_cmd_function = function() {
     // :function {name}
     if (this.reader.peekn(1) != "(") {
         this.reader.seek_set(pos);
-        return this.parse_cmd_common();
+        this.parse_cmd_common();
+        return;
     }
     // :function[!] {name}([arguments]) [range] [abort] [dict] [closure]
     var node = Node(NODE_FUNCTION);
@@ -1635,7 +1638,8 @@ VimLParser.prototype.parse_cmd_let = function() {
     // :let
     if (this.ends_excmds(this.reader.peek())) {
         this.reader.seek_set(pos);
-        return this.parse_cmd_common();
+        this.parse_cmd_common();
+        return;
     }
     var lhs = this.parse_letlhs();
     this.reader.skip_white();
@@ -1644,7 +1648,8 @@ VimLParser.prototype.parse_cmd_let = function() {
     // :let {var-name} ..
     if (this.ends_excmds(s1) || s2 != "+=" && s2 != "-=" && s2 != ".=" && s1 != "=") {
         this.reader.seek_set(pos);
-        return this.parse_cmd_common();
+        this.parse_cmd_common();
+        return;
     }
     // :let left op right
     var node = Node(NODE_LET);
@@ -3771,73 +3776,73 @@ Compiler.prototype.compile = function(node) {
         return this.compile_toplevel(node);
     }
     else if (node.type == NODE_COMMENT) {
-        return this.compile_comment(node);
+        this.compile_comment(node);
     }
     else if (node.type == NODE_EXCMD) {
-        return this.compile_excmd(node);
+        this.compile_excmd(node);
     }
     else if (node.type == NODE_FUNCTION) {
-        return this.compile_function(node);
+        this.compile_function(node);
     }
     else if (node.type == NODE_DELFUNCTION) {
-        return this.compile_delfunction(node);
+        this.compile_delfunction(node);
     }
     else if (node.type == NODE_RETURN) {
-        return this.compile_return(node);
+        this.compile_return(node);
     }
     else if (node.type == NODE_EXCALL) {
-        return this.compile_excall(node);
+        this.compile_excall(node);
     }
     else if (node.type == NODE_LET) {
-        return this.compile_let(node);
+        this.compile_let(node);
     }
     else if (node.type == NODE_UNLET) {
-        return this.compile_unlet(node);
+        this.compile_unlet(node);
     }
     else if (node.type == NODE_LOCKVAR) {
-        return this.compile_lockvar(node);
+        this.compile_lockvar(node);
     }
     else if (node.type == NODE_UNLOCKVAR) {
-        return this.compile_unlockvar(node);
+        this.compile_unlockvar(node);
     }
     else if (node.type == NODE_IF) {
-        return this.compile_if(node);
+        this.compile_if(node);
     }
     else if (node.type == NODE_WHILE) {
-        return this.compile_while(node);
+        this.compile_while(node);
     }
     else if (node.type == NODE_FOR) {
-        return this.compile_for(node);
+        this.compile_for(node);
     }
     else if (node.type == NODE_CONTINUE) {
-        return this.compile_continue(node);
+        this.compile_continue(node);
     }
     else if (node.type == NODE_BREAK) {
-        return this.compile_break(node);
+        this.compile_break(node);
     }
     else if (node.type == NODE_TRY) {
-        return this.compile_try(node);
+        this.compile_try(node);
     }
     else if (node.type == NODE_THROW) {
-        return this.compile_throw(node);
+        this.compile_throw(node);
     }
     else if (node.type == NODE_ECHO) {
-        return this.compile_echo(node);
+        this.compile_echo(node);
     }
     else if (node.type == NODE_ECHON) {
-        return this.compile_echon(node);
+        this.compile_echon(node);
     }
     else if (node.type == NODE_ECHOHL) {
-        return this.compile_echohl(node);
+        this.compile_echohl(node);
     }
     else if (node.type == NODE_ECHOMSG) {
-        return this.compile_echomsg(node);
+        this.compile_echomsg(node);
     }
     else if (node.type == NODE_ECHOERR) {
-        return this.compile_echoerr(node);
+        this.compile_echoerr(node);
     }
     else if (node.type == NODE_EXECUTE) {
-        return this.compile_execute(node);
+        this.compile_execute(node);
     }
     else if (node.type == NODE_TERNARY) {
         return this.compile_ternary(node);
@@ -4016,6 +4021,7 @@ Compiler.prototype.compile = function(node) {
     else {
         throw viml_printf("Compiler: unknown node: %s", viml_string(node));
     }
+    return NIL;
 }
 
 Compiler.prototype.compile_body = function(body) {

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -3777,72 +3777,95 @@ Compiler.prototype.compile = function(node) {
     }
     else if (node.type == NODE_COMMENT) {
         this.compile_comment(node);
+        return NIL;
     }
     else if (node.type == NODE_EXCMD) {
         this.compile_excmd(node);
+        return NIL;
     }
     else if (node.type == NODE_FUNCTION) {
         this.compile_function(node);
+        return NIL;
     }
     else if (node.type == NODE_DELFUNCTION) {
         this.compile_delfunction(node);
+        return NIL;
     }
     else if (node.type == NODE_RETURN) {
         this.compile_return(node);
+        return NIL;
     }
     else if (node.type == NODE_EXCALL) {
         this.compile_excall(node);
+        return NIL;
     }
     else if (node.type == NODE_LET) {
         this.compile_let(node);
+        return NIL;
     }
     else if (node.type == NODE_UNLET) {
         this.compile_unlet(node);
+        return NIL;
     }
     else if (node.type == NODE_LOCKVAR) {
         this.compile_lockvar(node);
+        return NIL;
     }
     else if (node.type == NODE_UNLOCKVAR) {
         this.compile_unlockvar(node);
+        return NIL;
     }
     else if (node.type == NODE_IF) {
         this.compile_if(node);
+        return NIL;
     }
     else if (node.type == NODE_WHILE) {
         this.compile_while(node);
+        return NIL;
     }
     else if (node.type == NODE_FOR) {
         this.compile_for(node);
+        return NIL;
     }
     else if (node.type == NODE_CONTINUE) {
         this.compile_continue(node);
+        return NIL;
     }
     else if (node.type == NODE_BREAK) {
         this.compile_break(node);
+        return NIL;
     }
     else if (node.type == NODE_TRY) {
         this.compile_try(node);
+        return NIL;
     }
     else if (node.type == NODE_THROW) {
         this.compile_throw(node);
+        return NIL;
     }
     else if (node.type == NODE_ECHO) {
         this.compile_echo(node);
+        return NIL;
     }
     else if (node.type == NODE_ECHON) {
         this.compile_echon(node);
+        return NIL;
     }
     else if (node.type == NODE_ECHOHL) {
         this.compile_echohl(node);
+        return NIL;
     }
     else if (node.type == NODE_ECHOMSG) {
         this.compile_echomsg(node);
+        return NIL;
     }
     else if (node.type == NODE_ECHOERR) {
         this.compile_echoerr(node);
+        return NIL;
     }
     else if (node.type == NODE_EXECUTE) {
         this.compile_execute(node);
+        return NIL;
     }
     else if (node.type == NODE_TERNARY) {
         return this.compile_ternary(node);

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -3011,50 +3011,73 @@ class Compiler:
             return self.compile_toplevel(node)
         elif node.type == NODE_COMMENT:
             self.compile_comment(node)
+            return NIL
         elif node.type == NODE_EXCMD:
             self.compile_excmd(node)
+            return NIL
         elif node.type == NODE_FUNCTION:
             self.compile_function(node)
+            return NIL
         elif node.type == NODE_DELFUNCTION:
             self.compile_delfunction(node)
+            return NIL
         elif node.type == NODE_RETURN:
             self.compile_return(node)
+            return NIL
         elif node.type == NODE_EXCALL:
             self.compile_excall(node)
+            return NIL
         elif node.type == NODE_LET:
             self.compile_let(node)
+            return NIL
         elif node.type == NODE_UNLET:
             self.compile_unlet(node)
+            return NIL
         elif node.type == NODE_LOCKVAR:
             self.compile_lockvar(node)
+            return NIL
         elif node.type == NODE_UNLOCKVAR:
             self.compile_unlockvar(node)
+            return NIL
         elif node.type == NODE_IF:
             self.compile_if(node)
+            return NIL
         elif node.type == NODE_WHILE:
             self.compile_while(node)
+            return NIL
         elif node.type == NODE_FOR:
             self.compile_for(node)
+            return NIL
         elif node.type == NODE_CONTINUE:
             self.compile_continue(node)
+            return NIL
         elif node.type == NODE_BREAK:
             self.compile_break(node)
+            return NIL
         elif node.type == NODE_TRY:
             self.compile_try(node)
+            return NIL
         elif node.type == NODE_THROW:
             self.compile_throw(node)
+            return NIL
         elif node.type == NODE_ECHO:
             self.compile_echo(node)
+            return NIL
         elif node.type == NODE_ECHON:
             self.compile_echon(node)
+            return NIL
         elif node.type == NODE_ECHOHL:
             self.compile_echohl(node)
+            return NIL
         elif node.type == NODE_ECHOMSG:
             self.compile_echomsg(node)
+            return NIL
         elif node.type == NODE_ECHOERR:
             self.compile_echoerr(node)
+            return NIL
         elif node.type == NODE_EXECUTE:
             self.compile_execute(node)
+            return NIL
         elif node.type == NODE_TERNARY:
             return self.compile_ternary(node)
         elif node.type == NODE_OR:

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -1092,7 +1092,7 @@ class VimLParser:
         self.add_node(node)
 
     def parse_cmd_insert(self):
-        return self.parse_cmd_append()
+        self.parse_cmd_append()
 
     def parse_cmd_loadkeymap(self):
         self.reader.setpos(self.ea.linepos)
@@ -1140,22 +1140,22 @@ class VimLParser:
         self.add_node(node)
 
     def parse_cmd_mzscheme(self):
-        return self.parse_cmd_lua()
+        self.parse_cmd_lua()
 
     def parse_cmd_perl(self):
-        return self.parse_cmd_lua()
+        self.parse_cmd_lua()
 
     def parse_cmd_python(self):
-        return self.parse_cmd_lua()
+        self.parse_cmd_lua()
 
     def parse_cmd_python3(self):
-        return self.parse_cmd_lua()
+        self.parse_cmd_lua()
 
     def parse_cmd_ruby(self):
-        return self.parse_cmd_lua()
+        self.parse_cmd_lua()
 
     def parse_cmd_tcl(self):
-        return self.parse_cmd_lua()
+        self.parse_cmd_lua()
 
     def parse_cmd_finish(self):
         self.parse_cmd_common()
@@ -1164,7 +1164,7 @@ class VimLParser:
 
 # FIXME
     def parse_cmd_usercmd(self):
-        return self.parse_cmd_common()
+        self.parse_cmd_common()
 
     def parse_cmd_function(self):
         pos = self.reader.tell()
@@ -1172,11 +1172,13 @@ class VimLParser:
         # :function
         if self.ends_excmds(self.reader.peek()):
             self.reader.seek_set(pos)
-            return self.parse_cmd_common()
+            self.parse_cmd_common()
+            return
         # :function /pattern
         if self.reader.peekn(1) == "/":
             self.reader.seek_set(pos)
-            return self.parse_cmd_common()
+            self.parse_cmd_common()
+            return
         left = self.parse_lvalue_func()
         self.reader.skip_white()
         if left.type == NODE_IDENTIFIER:
@@ -1187,7 +1189,8 @@ class VimLParser:
         # :function {name}
         if self.reader.peekn(1) != "(":
             self.reader.seek_set(pos)
-            return self.parse_cmd_common()
+            self.parse_cmd_common()
+            return
         # :function[!] {name}([arguments]) [range] [abort] [dict] [closure]
         node = Node(NODE_FUNCTION)
         node.pos = self.ea.cmdpos
@@ -1312,7 +1315,8 @@ class VimLParser:
         # :let
         if self.ends_excmds(self.reader.peek()):
             self.reader.seek_set(pos)
-            return self.parse_cmd_common()
+            self.parse_cmd_common()
+            return
         lhs = self.parse_letlhs()
         self.reader.skip_white()
         s1 = self.reader.peekn(1)
@@ -1320,7 +1324,8 @@ class VimLParser:
         # :let {var-name} ..
         if self.ends_excmds(s1) or s2 != "+=" and s2 != "-=" and s2 != ".=" and s1 != "=":
             self.reader.seek_set(pos)
-            return self.parse_cmd_common()
+            self.parse_cmd_common()
+            return
         # :let left op right
         node = Node(NODE_LET)
         node.pos = self.ea.cmdpos
@@ -3005,51 +3010,51 @@ class Compiler:
         if node.type == NODE_TOPLEVEL:
             return self.compile_toplevel(node)
         elif node.type == NODE_COMMENT:
-            return self.compile_comment(node)
+            self.compile_comment(node)
         elif node.type == NODE_EXCMD:
-            return self.compile_excmd(node)
+            self.compile_excmd(node)
         elif node.type == NODE_FUNCTION:
-            return self.compile_function(node)
+            self.compile_function(node)
         elif node.type == NODE_DELFUNCTION:
-            return self.compile_delfunction(node)
+            self.compile_delfunction(node)
         elif node.type == NODE_RETURN:
-            return self.compile_return(node)
+            self.compile_return(node)
         elif node.type == NODE_EXCALL:
-            return self.compile_excall(node)
+            self.compile_excall(node)
         elif node.type == NODE_LET:
-            return self.compile_let(node)
+            self.compile_let(node)
         elif node.type == NODE_UNLET:
-            return self.compile_unlet(node)
+            self.compile_unlet(node)
         elif node.type == NODE_LOCKVAR:
-            return self.compile_lockvar(node)
+            self.compile_lockvar(node)
         elif node.type == NODE_UNLOCKVAR:
-            return self.compile_unlockvar(node)
+            self.compile_unlockvar(node)
         elif node.type == NODE_IF:
-            return self.compile_if(node)
+            self.compile_if(node)
         elif node.type == NODE_WHILE:
-            return self.compile_while(node)
+            self.compile_while(node)
         elif node.type == NODE_FOR:
-            return self.compile_for(node)
+            self.compile_for(node)
         elif node.type == NODE_CONTINUE:
-            return self.compile_continue(node)
+            self.compile_continue(node)
         elif node.type == NODE_BREAK:
-            return self.compile_break(node)
+            self.compile_break(node)
         elif node.type == NODE_TRY:
-            return self.compile_try(node)
+            self.compile_try(node)
         elif node.type == NODE_THROW:
-            return self.compile_throw(node)
+            self.compile_throw(node)
         elif node.type == NODE_ECHO:
-            return self.compile_echo(node)
+            self.compile_echo(node)
         elif node.type == NODE_ECHON:
-            return self.compile_echon(node)
+            self.compile_echon(node)
         elif node.type == NODE_ECHOHL:
-            return self.compile_echohl(node)
+            self.compile_echohl(node)
         elif node.type == NODE_ECHOMSG:
-            return self.compile_echomsg(node)
+            self.compile_echomsg(node)
         elif node.type == NODE_ECHOERR:
-            return self.compile_echoerr(node)
+            self.compile_echoerr(node)
         elif node.type == NODE_EXECUTE:
-            return self.compile_execute(node)
+            self.compile_execute(node)
         elif node.type == NODE_TERNARY:
             return self.compile_ternary(node)
         elif node.type == NODE_OR:
@@ -3168,6 +3173,7 @@ class Compiler:
             return self.compile_lambda(node)
         else:
             raise VimLParserException(viml_printf("Compiler: unknown node: %s", viml_string(node)))
+        return NIL
 
     def compile_body(self, body):
         for node in body:


### PR DESCRIPTION
return FUNC where FUNC returns nothing cannot be translated into
languages which doens't support this functionality (e.g. Go).