### PR TITLE
Fix USERCMD regex and py/js support

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -746,7 +746,7 @@ function! s:VimLParser.parse_command()
     let self.ea.forceit = s:FALSE
   endif
 
-  if self.ea.cmd.flags !~# '\<BANG\>' && self.ea.forceit && self.ea.cmd.flags !~# 'USERCMD'
+  if self.ea.cmd.flags !~# '\<BANG\>' && self.ea.forceit && self.ea.cmd.flags !~# '\<USERCMD\>'
     throw s:Err('E477: No ! allowed', self.ea.cmdpos)
   endif
 

--- a/js/vimlfunc.js
+++ b/js/vimlfunc.js
@@ -35,6 +35,7 @@ var pat_vim2js = {
   "\\<NOTRLCOM\\>" : "\\bNOTRLCOM\\b",
   "\\<TRLBAR\\>" : "\\bTRLBAR\\b",
   "\\<USECTRLV\\>" : "\\bUSECTRLV\\b",
+  "\\<USERCMD\\>" : "\\bUSERCMD\\b",
   "\\<\\(XFILE\\|FILES\\|FILE1\\)\\>" : "\\b(XFILE|FILES|FILE1)\\b",
   "\\S" : "\\S",
   "\\a" : "[A-Za-z]",

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -35,6 +35,7 @@ var pat_vim2js = {
   "\\<NOTRLCOM\\>" : "\\bNOTRLCOM\\b",
   "\\<TRLBAR\\>" : "\\bTRLBAR\\b",
   "\\<USECTRLV\\>" : "\\bUSECTRLV\\b",
+  "\\<USERCMD\\>" : "\\bUSERCMD\\b",
   "\\<\\(XFILE\\|FILES\\|FILE1\\)\\>" : "\\b(XFILE|FILES|FILE1)\\b",
   "\\S" : "\\S",
   "\\a" : "[A-Za-z]",
@@ -969,7 +970,7 @@ VimLParser.prototype.parse_command = function() {
     else {
         this.ea.forceit = FALSE;
     }
-    if (!viml_eqregh(this.ea.cmd.flags, "\\<BANG\\>") && this.ea.forceit && !viml_eqregh(this.ea.cmd.flags, "USERCMD")) {
+    if (!viml_eqregh(this.ea.cmd.flags, "\\<BANG\\>") && this.ea.forceit && !viml_eqregh(this.ea.cmd.flags, "\\<USERCMD\\>")) {
         throw Err("E477: No ! allowed", this.ea.cmdpos);
     }
     if (this.ea.cmd.name != "!") {

--- a/py/vimlfunc.py
+++ b/py/vimlfunc.py
@@ -31,6 +31,7 @@ pat_vim2py = {
   "\\<NOTRLCOM\\>" : "\\bNOTRLCOM\\b",
   "\\<TRLBAR\\>" : "\\bTRLBAR\\b",
   "\\<USECTRLV\\>" : "\\bUSECTRLV\\b",
+  "\\<USERCMD\\>" : "\\bUSERCMD\\b",
   "\\<\\(XFILE\\|FILES\\|FILE1\\)\\>" : "\\b(XFILE|FILES|FILE1)\\b",
   "\\S" : "\\S",
   "\\a" : "[A-Za-z]",

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -31,6 +31,7 @@ pat_vim2py = {
   "\\<NOTRLCOM\\>" : "\\bNOTRLCOM\\b",
   "\\<TRLBAR\\>" : "\\bTRLBAR\\b",
   "\\<USECTRLV\\>" : "\\bUSECTRLV\\b",
+  "\\<USERCMD\\>" : "\\bUSERCMD\\b",
   "\\<\\(XFILE\\|FILES\\|FILE1\\)\\>" : "\\b(XFILE|FILES|FILE1)\\b",
   "\\S" : "\\S",
   "\\a" : "[A-Za-z]",
@@ -805,7 +806,7 @@ class VimLParser:
             self.ea.forceit = TRUE
         else:
             self.ea.forceit = FALSE
-        if not viml_eqregh(self.ea.cmd.flags, "\\<BANG\\>") and self.ea.forceit and not viml_eqregh(self.ea.cmd.flags, "USERCMD"):
+        if not viml_eqregh(self.ea.cmd.flags, "\\<BANG\\>") and self.ea.forceit and not viml_eqregh(self.ea.cmd.flags, "\\<USERCMD\\>"):
             raise VimLParserException(Err("E477: No ! allowed", self.ea.cmdpos))
         if self.ea.cmd.name != "!":
             self.reader.skip_white()


### PR DESCRIPTION
I forgot to update the regex table for Python/JavaScript in #28.
This patch fixes it and also uses more appropriate regex.