### PR TITLE
Introduce parentheses expression node 

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -137,6 +137,7 @@ let s:NODE_REG = 89
 let s:NODE_CURLYNAMEPART = 90
 let s:NODE_CURLYNAMEEXPR = 91
 let s:NODE_LAMBDA = 92
+let s:NODE_PARENEXPR = 93
 
 let s:TOKEN_EOF = 1
 let s:TOKEN_EOL = 2
@@ -403,6 +404,7 @@ endfunction
 " CURLYNAMEPART .value
 " CURLYNAMEEXPR .value
 " LAMBDA .rlist .left
+" PARENEXPR .value
 function! s:Node(type)
   return {'type': a:type}
 endfunction
@@ -3521,7 +3523,9 @@ function! s:ExprParser.parse_expr9()
     endwhile
     return node
   elseif token.type == s:TOKEN_POPEN
-    let node = self.parse_expr1()
+    let node = s:Node(s:NODE_PARENEXPR)
+    let node.pos = token.pos
+    let node.value = self.parse_expr1()
     let token = self.tokenizer.get()
     if token.type != s:TOKEN_PCLOSE
       throw s:Err(printf('unexpected token: %s', token.value), token.pos)
@@ -4222,6 +4226,8 @@ function! s:Compiler.compile(node)
     return self.compile_curlynameexpr(a:node)
   elseif a:node.type == s:NODE_LAMBDA
     return self.compile_lambda(a:node)
+  elseif a:node.type == s:NODE_PARENEXPR
+    return self.compile_parenexpr(a:node)
   else
     throw printf('Compiler: unknown node: %s', string(a:node))
   endif
@@ -4683,6 +4689,10 @@ endfunction
 function! s:Compiler.compile_lambda(node)
   let rlist = map(a:node.rlist, 'self.compile(v:val)')
   return printf('(lambda (%s) %s)', join(rlist, ' '), self.compile(a:node.left))
+endfunction
+
+function! s:Compiler.compile_parenexpr(node)
+  return self.compile(a:node.value)
 endfunction
 
 " TODO: under construction

--- a/js/jscompiler.vim
+++ b/js/jscompiler.vim
@@ -3,6 +3,7 @@ call extend(s:, vimlparser#import())
 
 let s:opprec = {}
 let s:opprec[s:NODE_TERNARY] = 1
+let s:opprec[s:NODE_PARENEXPR] = 1
 let s:opprec[s:NODE_OR] = 2
 let s:opprec[s:NODE_AND] = 3
 let s:opprec[s:NODE_EQUAL] = 4
@@ -254,6 +255,8 @@ function s:JavascriptCompiler.compile(node)
     return self.compile_env(a:node)
   elseif a:node.type == s:NODE_REG
     return self.compile_reg(a:node)
+  elseif a:node.type == s:NODE_PARENEXPR
+    return self.compile_parenexpr(a:node)
   else
     throw self.err('Compiler: unknown node: %s', string(a:node))
   endif
@@ -816,6 +819,10 @@ endfunction
 
 function s:JavascriptCompiler.compile_reg(node)
   throw 'NotImplemented: reg'
+endfunction
+
+function s:JavascriptCompiler.compile_parenexpr(node)
+  return self.compile(a:node.value)
 endfunction
 
 function s:JavascriptCompiler.compile_op1(node, op)

--- a/py/pycompiler.vim
+++ b/py/pycompiler.vim
@@ -3,6 +3,7 @@ call extend(s:, vimlparser#import())
 
 let s:opprec = {}
 let s:opprec[s:NODE_TERNARY] = 1
+let s:opprec[s:NODE_PARENEXPR] = 1
 let s:opprec[s:NODE_OR] = 2
 let s:opprec[s:NODE_AND] = 3
 let s:opprec[s:NODE_EQUAL] = 4
@@ -290,6 +291,8 @@ function s:PythonCompiler.compile(node)
     return self.compile_env(a:node)
   elseif a:node.type == s:NODE_REG
     return self.compile_reg(a:node)
+  elseif a:node.type == s:NODE_PARENEXPR
+    return self.compile_parenexpr(a:node)
   else
     throw self.err('Compiler: unknown node: %s', string(a:node))
   endif
@@ -797,6 +800,10 @@ endfunction
 
 function s:PythonCompiler.compile_reg(node)
   throw 'NotImplemented: reg'
+endfunction
+
+function s:PythonCompiler.compile_parenexpr(node)
+  return self.compile(a:node.value)
 endfunction
 
 function s:PythonCompiler.compile_op1(node, op)

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -281,6 +281,7 @@ NODE_REG = 89
 NODE_CURLYNAMEPART = 90
 NODE_CURLYNAMEEXPR = 91
 NODE_LAMBDA = 92
+NODE_PARENEXPR = 93
 TOKEN_EOF = 1
 TOKEN_EOL = 2
 TOKEN_SPACE = 3
@@ -528,6 +529,7 @@ def ExArg():
 # CURLYNAMEPART .value
 # CURLYNAMEEXPR .value
 # LAMBDA .rlist .left
+# PARENEXPR .value
 def Node(type):
     return AttributeDict({"type":type})
 
@@ -1140,7 +1142,7 @@ class VimLParser:
                 if c != "`":
                     raise VimLParserException(Err(viml_printf("unexpected character: %s", c), self.reader.getpos()))
                 self.reader.getn(1)
-            elif c == "|" or c == "\n" or c == "\"" and not viml_eqregh(self.ea.cmd.flags, "\\<NOTRLCOM\\>") and (self.ea.cmd.name != "@" and self.ea.cmd.name != "*" or self.reader.getpos() != self.ea.argpos) and (self.ea.cmd.name != "redir" or self.reader.getpos().i != self.ea.argpos.i + 1 or pc != "@"):
+            elif c == "|" or c == "\n" or (c == "\"" and not viml_eqregh(self.ea.cmd.flags, "\\<NOTRLCOM\\>") and ((self.ea.cmd.name != "@" and self.ea.cmd.name != "*") or self.reader.getpos() != self.ea.argpos) and (self.ea.cmd.name != "redir" or self.reader.getpos().i != self.ea.argpos.i + 1 or pc != "@")):
                 has_cpo_bar = FALSE
                 # &cpoptions =~ 'b'
                 if (not has_cpo_bar or not viml_eqregh(self.ea.cmd.flags, "\\<USECTRLV\\>")) and pc == "\\":
@@ -1421,7 +1423,7 @@ class VimLParser:
         s1 = self.reader.peekn(1)
         s2 = self.reader.peekn(2)
         # :let {var-name} ..
-        if self.ends_excmds(s1) or s2 != "+=" and s2 != "-=" and s2 != ".=" and s1 != "=":
+        if self.ends_excmds(s1) or (s2 != "+=" and s2 != "-=" and s2 != ".=" and s1 != "="):
             self.reader.seek_set(pos)
             self.parse_cmd_common()
             return
@@ -1860,7 +1862,7 @@ class ExprTokenizer:
             if r.p(0) == "." and isdigit(r.p(1)):
                 s += r.getn(1)
                 s += r.read_digit()
-                if (r.p(0) == "E" or r.p(0) == "e") and (isdigit(r.p(1)) or (r.p(1) == "-" or r.p(1) == "+") and isdigit(r.p(2))):
+                if (r.p(0) == "E" or r.p(0) == "e") and (isdigit(r.p(1)) or ((r.p(1) == "-" or r.p(1) == "+") and isdigit(r.p(2)))):
                     s += r.getn(2)
                     s += r.read_digit()
             return self.token(TOKEN_NUMBER, s, pos)
@@ -2708,7 +2710,9 @@ class ExprParser:
                     raise VimLParserException(Err(viml_printf("unexpected token: %s", token.value), token.pos))
             return node
         elif token.type == TOKEN_POPEN:
-            node = self.parse_expr1()
+            node = Node(NODE_PARENEXPR)
+            node.pos = token.pos
+            node.value = self.parse_expr1()
             token = self.tokenizer.get()
             if token.type != TOKEN_PCLOSE:
                 raise VimLParserException(Err(viml_printf("unexpected token: %s", token.value), token.pos))
@@ -3308,6 +3312,8 @@ class Compiler:
             return self.compile_curlynameexpr(node)
         elif node.type == NODE_LAMBDA:
             return self.compile_lambda(node)
+        elif node.type == NODE_PARENEXPR:
+            return self.compile_parenexpr(node)
         else:
             raise VimLParserException(viml_printf("Compiler: unknown node: %s", viml_string(node)))
         return NIL
@@ -3667,6 +3673,9 @@ class Compiler:
     def compile_lambda(self, node):
         rlist = [self.compile(vval) for vval in node.rlist]
         return viml_printf("(lambda (%s) %s)", viml_join(rlist, " "), self.compile(node.left))
+
+    def compile_parenexpr(self, node):
+        return self.compile(node.value)
 
 # TODO: under construction
 class RegexpParser:


### PR DESCRIPTION
This p-r indroduces s:NODE_PARENEXPR node which represents `(...)` expression.

Prior to this change, vimlparser completely dropped `(...)` data, so we cannot know binary expression is surrouneded with `()` or not.
For exampele, if we want to write printer of Vim AST, 1 + 2 * 3 becomes (1 + (2 * 3)) ref: #70

One big problem is that it's breaking feature.
Existing vimlparser users have to update to handle new node.

At first i thought we can add a flag to enable it, but on second thought,
it's good to change how vimlparser works by flag and it will slows down future development.

Instead, maybe we can notify vimlparser users to update script and/or make p-r for this change.
Fortunately, it will be really easy changes.

What do you think?