### PR TITLE
Add pos to NODE_TOPLEVEL

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -486,6 +486,7 @@ function! s:VimLParser.parse(reader)
   let self.reader = a:reader
   let self.context = []
   let toplevel = s:Node(s:NODE_TOPLEVEL)
+  let toplevel.pos = self.reader.getpos()
   let toplevel.body = []
   call self.push_context(toplevel)
   while self.reader.peek() !=# '<EOF>'

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -669,6 +669,7 @@ VimLParser.prototype.parse = function(reader) {
     this.reader = reader;
     this.context = [];
     var toplevel = Node(NODE_TOPLEVEL);
+    toplevel.pos = this.reader.getpos();
     toplevel.body = [];
     this.push_context(toplevel);
     while (this.reader.peek() != "<EOF>") {

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -583,6 +583,7 @@ class VimLParser:
         self.reader = reader
         self.context = []
         toplevel = Node(NODE_TOPLEVEL)
+        toplevel.pos = self.reader.getpos()
         toplevel.body = []
         self.push_context(toplevel)
         while self.reader.peek() != "<EOF>":


### PR DESCRIPTION
It's convenient to ensure that all node have position data.
Currently, only NODE_TOPLEVEL doesn't have position.

btw, I want to write unite tests, but vimlparser doesn't setup writing unit tests.
maybe we should file a bug and setup testing framework?
e.g. use https://github.com/thinca/vim-themis or create something like runtest.vim in Vim.