### PR TITLE
Change s:isnamec to only include colon with scope

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -239,7 +239,7 @@ function! s:iswhite(c)
 endfunction
 
 function! s:isnamec(c)
-  return a:c =~# '^[0-9A-Za-z_:#]$'
+  return a:c =~# '^([bgls]:)?[0-9A-Za-z_#]$'
 endfunction
 
 function! s:isnamec1(c)


### PR DESCRIPTION
Fixes https://github.com/vim-jp/vim-vimlparser/issues/79.