### PR TITLE
Support binary number literals (e.g. 0b0, 0b1011)

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -2576,6 +2576,10 @@ function! s:ExprTokenizer.get2()
     let s = r.getn(3)
     let s .= r.read_xdigit()
     return self.token(s:TOKEN_NUMBER, s, pos)
+  elseif c ==# '0' && (r.p(1) ==# 'B' || r.p(1) ==# 'b') && (r.p(2) == '0' || r.p(2) == '1')
+    let s = r.getn(3)
+    let s .= r.read_bdigit()
+    return self.token(s:TOKEN_NUMBER, s, pos)
   elseif s:isdigit(c)
     let s = r.read_digit()
     if r.p(0) ==# '.' && s:isdigit(r.p(1))
@@ -3940,6 +3944,14 @@ endfunction
 function! s:StringReader.read_xdigit()
   let r = ''
   while s:isxdigit(self.peekn(1))
+    let r .= self.getn(1)
+  endwhile
+  return r
+endfunction
+
+function! s:StringReader.read_bdigit()
+  let r = ''
+  while self.peekn(1) == '0' || self.peekn(1) == '1'
     let r .= self.getn(1)
   endwhile
   return r

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -2324,6 +2324,11 @@ ExprTokenizer.prototype.get2 = function() {
         s += r.read_xdigit();
         return this.token(TOKEN_NUMBER, s, pos);
     }
+    else if (c == "0" && (r.p(1) == "B" || r.p(1) == "b") && (r.p(2) == "0" || r.p(2) == "1")) {
+        var s = r.getn(3);
+        s += r.read_bdigit();
+        return this.token(TOKEN_NUMBER, s, pos);
+    }
     else if (isdigit(c)) {
         var s = r.read_digit();
         if (r.p(0) == "." && isdigit(r.p(1))) {
@@ -3844,6 +3849,14 @@ StringReader.prototype.read_odigit = function() {
 StringReader.prototype.read_xdigit = function() {
     var r = "";
     while (isxdigit(this.peekn(1))) {
+        r += this.getn(1);
+    }
+    return r;
+}
+
+StringReader.prototype.read_bdigit = function() {
+    var r = "";
+    while (this.peekn(1) == "0" || this.peekn(1) == "1") {
         r += this.getn(1);
     }
     return r;

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -1856,6 +1856,10 @@ class ExprTokenizer:
             s = r.getn(3)
             s += r.read_xdigit()
             return self.token(TOKEN_NUMBER, s, pos)
+        elif c == "0" and (r.p(1) == "B" or r.p(1) == "b") and (r.p(2) == "0" or r.p(2) == "1"):
+            s = r.getn(3)
+            s += r.read_bdigit()
+            return self.token(TOKEN_NUMBER, s, pos)
         elif isdigit(c):
             s = r.read_digit()
             if r.p(0) == "." and isdigit(r.p(1)):
@@ -3056,6 +3060,12 @@ class StringReader:
     def read_xdigit(self):
         r = ""
         while isxdigit(self.peekn(1)):
+            r += self.getn(1)
+        return r
+
+    def read_bdigit(self):
+        r = ""
+        while self.peekn(1) == "0" or self.peekn(1) == "1":
             r += self.getn(1)
         return r
 

--- a/test/test_number.ok
+++ b/test/test_number.ok
@@ -6,3 +6,5 @@
 (echo 1.2e-3)
 (echo 4.5E+67)
 (echo 4.5e8)
+(echo 0b1011)
+(echo 0b0)

--- a/test/test_number.ok
+++ b/test/test_number.ok
@@ -2,6 +2,7 @@
 (echo 1.0)
 (echo 1.23)
 (echo 0xdeadbeef)
+(echo 0Xdeadbeef)
 (echo 033)
 (echo 1.2e-3)
 (echo 4.5E+67)

--- a/test/test_number.ok
+++ b/test/test_number.ok
@@ -8,3 +8,5 @@
 (echo 4.5e8)
 (echo 0b1011)
 (echo 0b0)
+(echo 0B1011)
+(echo 0B0)

--- a/test/test_number.ok
+++ b/test/test_number.ok
@@ -11,3 +11,4 @@
 (echo 0b0)
 (echo 0B1011)
 (echo 0B0)
+(echo 0b01 23)

--- a/test/test_number.vim
+++ b/test/test_number.vim
@@ -8,3 +8,5 @@ echo 4.5E+67
 echo 4.5e8
 echo 0b1011
 echo 0b0
+echo 0B1011
+echo 0B0

--- a/test/test_number.vim
+++ b/test/test_number.vim
@@ -6,3 +6,5 @@ echo 033
 echo 1.2e-3
 echo 4.5E+67
 echo 4.5e8
+echo 0b1011
+echo 0b0

--- a/test/test_number.vim
+++ b/test/test_number.vim
@@ -2,6 +2,7 @@ echo 1
 echo 1.0
 echo 1.23
 echo 0xdeadbeef
+echo 0Xdeadbeef
 echo 033
 echo 1.2e-3
 echo 4.5E+67

--- a/test/test_number.vim
+++ b/test/test_number.vim
@@ -11,3 +11,4 @@ echo 0b1011
 echo 0b0
 echo 0B1011
 echo 0B0
+echo 0b0123


### PR DESCRIPTION
I found Vim script has binary number literals (e.g. 0b0, 0b1011), and they are not supported yet.
Fixed tokenizer to support it.

Sorry, I don't check from when the literal format is supported...