### PR TITLE
get_token_sq_c: skip char2nr for fixed values

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -5264,16 +5264,16 @@ function! s:RegexpParser.get_token_sq_c()
       return ['\n', 0]
     elseif c ==# 'r'
       call self.reader.seek_cur(1)
-      return ['\r', char2nr("\r")]
+      return ['\r', 13]
     elseif c ==# 't'
       call self.reader.seek_cur(1)
-      return ['\t', char2nr("\t")]
+      return ['\t', 9]
     elseif c ==# 'e'
       call self.reader.seek_cur(1)
-      return ['\e', char2nr("\e")]
+      return ['\e', 27]
     elseif c ==# 'b'
       call self.reader.seek_cur(1)
-      return ['\b', char2nr("\b")]
+      return ['\b', 8]
     elseif stridx(']^-\', c) != -1
       call self.reader.seek_cur(1)
       return ['\' . c, char2nr(c)]

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -5361,19 +5361,19 @@ RegexpParser.prototype.get_token_sq_c = function() {
         }
         else if (c == "r") {
             this.reader.seek_cur(1);
-            return ["\\r", viml_char2nr("\r")];
+            return ["\\r", 13];
         }
         else if (c == "t") {
             this.reader.seek_cur(1);
-            return ["\\t", viml_char2nr("\t")];
+            return ["\\t", 9];
         }
         else if (c == "e") {
             this.reader.seek_cur(1);
-            return ["\\e", viml_char2nr("\e")];
+            return ["\\e", 27];
         }
         else if (c == "b") {
             this.reader.seek_cur(1);
-            return ["\\b", viml_char2nr("\b")];
+            return ["\\b", 8];
         }
         else if (viml_stridx("]^-\\", c) != -1) {
             this.reader.seek_cur(1);

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -4151,16 +4151,16 @@ class RegexpParser:
                 return ["\\n", 0]
             elif c == "r":
                 self.reader.seek_cur(1)
-                return ["\\r", viml_char2nr("\r")]
+                return ["\\r", 13]
             elif c == "t":
                 self.reader.seek_cur(1)
-                return ["\\t", viml_char2nr("\t")]
+                return ["\\t", 9]
             elif c == "e":
                 self.reader.seek_cur(1)
-                return ["\\e", viml_char2nr("\e")]
+                return ["\\e", 27]
             elif c == "b":
                 self.reader.seek_cur(1)
-                return ["\\b", viml_char2nr("\b")]
+                return ["\\b", 8]
             elif viml_stridx("]^-\\", c) != -1:
                 self.reader.seek_cur(1)
                 return ["\\" + c, viml_char2nr(c)]


### PR DESCRIPTION
In Python it would use `ord()`, which does not work for `"\e"`.

But apart from that `viml_char2nr` should probably be made to support/handle `\e`?
(Note however that "\e" is an invalid escape sequence in Python, so should be `r"\e"` there then)