### PR TITLE
Makefile: checkvim: use own/current vimlparser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ check: all
 checkpy: all
 	flake8 py
 
+# Run vint, using py/vimlparser.py.
 checkvim: all
-	vint autoload py/pycompiler.vim
+	PYTHONPATH=py vint autoload py/pycompiler.vim
 
 vim/test:
 	test/run.sh


### PR DESCRIPTION
Vint tries to import a non-bundled vimlparser first, which we can inject
using `PYTHONPATH`.
Ref: https://github.com/Kuniwak/vint/blob/219501b58c/vint/_bundles/__init__.py#L3-L8