### PR TITLE
.coveragerc: specific include

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
 plugins = covimerage
 data_file = .coverage_covimerage
+include = py/*.py
 branch = 1


### PR DESCRIPTION
Improves performance when tracking (Python) coverage.
Likely needed for covimerage also.