### PR TITLE
Fix format specifier for node.depth

### DIFF
--- a/autoload/vimlparser.vim
+++ b/autoload/vimlparser.vim
@@ -5183,7 +5183,7 @@ function! s:Compiler.compile_lockvar(node) abort
   if a:node.depth is# s:NIL
     call self.out('(lockvar %s)', join(list, ' '))
   else
-    call self.out('(lockvar %s %s)', a:node.depth, join(list, ' '))
+    call self.out('(lockvar %d %s)', a:node.depth, join(list, ' '))
   endif
 endfunction
 
@@ -5192,7 +5192,7 @@ function! s:Compiler.compile_unlockvar(node) abort
   if a:node.depth is# s:NIL
     call self.out('(unlockvar %s)', join(list, ' '))
   else
-    call self.out('(unlockvar %s %s)', a:node.depth, join(list, ' '))
+    call self.out('(unlockvar %d %s)', a:node.depth, join(list, ' '))
   endif
 endfunction
 

--- a/js/vimlparser.js
+++ b/js/vimlparser.js
@@ -4673,7 +4673,7 @@ Compiler.prototype.compile_lockvar = function(node) {
         this.out("(lockvar %s)", viml_join(list, " "));
     }
     else {
-        this.out("(lockvar %s %s)", node.depth, viml_join(list, " "));
+        this.out("(lockvar %d %s)", node.depth, viml_join(list, " "));
     }
 }
 
@@ -4683,7 +4683,7 @@ Compiler.prototype.compile_unlockvar = function(node) {
         this.out("(unlockvar %s)", viml_join(list, " "));
     }
     else {
-        this.out("(unlockvar %s %s)", node.depth, viml_join(list, " "));
+        this.out("(unlockvar %d %s)", node.depth, viml_join(list, " "));
     }
 }
 

--- a/py/vimlparser.py
+++ b/py/vimlparser.py
@@ -3737,14 +3737,14 @@ class Compiler:
         if node.depth is NIL:
             self.out("(lockvar %s)", viml_join(list, " "))
         else:
-            self.out("(lockvar %s %s)", node.depth, viml_join(list, " "))
+            self.out("(lockvar %d %s)", node.depth, viml_join(list, " "))
 
     def compile_unlockvar(self, node):
         list = [self.compile(vval) for vval in node.list]
         if node.depth is NIL:
             self.out("(unlockvar %s)", viml_join(list, " "))
         else:
-            self.out("(unlockvar %s %s)", node.depth, viml_join(list, " "))
+            self.out("(unlockvar %d %s)", node.depth, viml_join(list, " "))
 
     def compile_if(self, node):
         self.out("(if %s", self.compile(node.cond))


### PR DESCRIPTION
Since node.depth is an integer, format specifier should be `%d`, not `%s`. Otherwise go-vimlparser cannot compile.