### PR TITLE
Disable default vimrc and viminfo in compile scripts

### DIFF
--- a/scripts/jscompile.bat
+++ b/scripts/jscompile.bat
@@ -1,2 +1,2 @@
 @echo off
-vim -E -s -N --cmd "set rtp+=." -c "exe 'so' argv()[0]" -c q -- js/jscompiler.vim %*
+vim -u NONE -i NONE -E -s -N --cmd "set rtp+=." -c "exe 'so' argv()[0]" -c q -- js/jscompiler.vim %*

--- a/scripts/jscompile.sh
+++ b/scripts/jscompile.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-vim -E -s -N --cmd 'set rtp+=.' -c 'exe "so" argv()[0]' -c q -- js/jscompiler.vim $*
+vim -u NONE -i NONE -E -s -N --cmd 'set rtp+=.' -c 'exe "so" argv()[0]' -c q -- js/jscompiler.vim $*

--- a/scripts/pycompile.bat
+++ b/scripts/pycompile.bat
@@ -1,2 +1,2 @@
 @echo off
-vim -E -s -N --cmd "set rtp+=." -c "exe 'so' argv()[0]" -c q -- py/pycompiler.vim %*
+vim -u NONE -i NONE -E -s -N --cmd "set rtp+=." -c "exe 'so' argv()[0]" -c q -- py/pycompiler.vim %*

--- a/scripts/pycompile.sh
+++ b/scripts/pycompile.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-vim -E -s -N --cmd 'set rtp+=.' -c 'exe "so" argv()[0]' -c q -- py/pycompiler.vim $*
+vim -u NONE -i NONE -E -s -N --cmd 'set rtp+=.' -c 'exe "so" argv()[0]' -c q -- py/pycompiler.vim $*


### PR DESCRIPTION
I noticed that current scripts writes ~/.viminfo. I think it's not intended so I added `-i NONE`.
On the other hand `-E -s` disables reading the default vimrc, but adding `-u NONE` not to rely on this implicit behavior.